### PR TITLE
deps: error_prone_annotations from shared deps BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.1.0')
+implementation platform('com.google.cloud:libraries-bom:25.2.0')
 
 implementation 'com.google.cloud:google-cloud-resourcemanager'
 ```

--- a/google-cloud-resourcemanager/pom.xml
+++ b/google-cloud-resourcemanager/pom.xml
@@ -65,11 +65,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.13.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
The shared dependencies BOM provides the latest error_prone_annotations version. No need to specify in individual repositories.